### PR TITLE
ci: minor fixes in gitlab actions configuration

### DIFF
--- a/.github/workflows/kappa.yml
+++ b/.github/workflows/kappa.yml
@@ -38,7 +38,7 @@ jobs:
           path: |
             node_modules
             */*/node_modules
-          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-kappa
       - run: yarn install
 
   build-kappa:
@@ -60,7 +60,7 @@ jobs:
           path: |
             node_modules
             */*/node_modules
-          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-kappa
       - run: yarn install
       - run: yarn run build
       - uses: actions/upload-artifact@v2
@@ -87,7 +87,7 @@ jobs:
           path: |
             node_modules
             */*/node_modules
-          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-kappa
       - run: yarn install
       - run: yarn test
 

--- a/.github/workflows/light.yml
+++ b/.github/workflows/light.yml
@@ -38,7 +38,7 @@ jobs:
           path: |
             node_modules
             */*/node_modules
-          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-light
       - run: yarn install
 
   build-light:
@@ -60,7 +60,7 @@ jobs:
           path: |
             node_modules
             */*/node_modules
-          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-light
       - run: yarn install
       - run: yarn run build
       - uses: actions/upload-artifact@v2
@@ -87,7 +87,7 @@ jobs:
           path: |
             node_modules
             */*/node_modules
-          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-light
       - run: yarn install
       - run: yarn test
 

--- a/services/kappa/app.yaml
+++ b/services/kappa/app.yaml
@@ -1,5 +1,5 @@
 runtime: nodejs12
-service: light
+service: kappa
 
 automatic_scaling:
   max_instances: 1


### PR DESCRIPTION
Related to #17 

This PR changes the cache keys in GitHub in order to have unique names for each service. Also, it changes the name of the `kappa` service in Google App Engine configuration file.